### PR TITLE
Support Laravel 10.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 7.4]
-        laravel: [9.*, 8.*, 7.*]
+        php: [8.1, 8.0]
+        laravel: [10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,15 +18,15 @@ jobs:
         laravel: [10.*, 9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
           - laravel: 9.*
             testbench: 7.*
           - laravel: 8.*
             testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
         exclude:
-          - laravel: 9.*
-            php: 7.4
+          - laravel: 10.*
+            php: 8.0
 
     name: PHP${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "laravel/framework": "^7.0 || ^8.0 || ^9.0"
+        "laravel/framework": "^7.0 || ^8.0 || ^9.0 || ^10.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0"
+        "orchestra/testbench": "^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" verbose="true">
-    <coverage includeUncoveredFiles="false">
-        <include>
-            <directory suffix=".php">
-                ./src/
-            </directory>
-        </include>
-    </coverage>
-    <testsuites>
-        <testsuite name="Tenancy Tests">
-            <directory suffix="Test.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.4/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <coverage includeUncoveredFiles="false"/>
+  <testsuites>
+    <testsuite name="Tenancy Tests">
+      <directory suffix="Test.php">
                 ./tests/
             </directory>
-        </testsuite>
-    </testsuites>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">
+                ./src/
+            </directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
```
$ vendor/bin/phpunit 
PHPUnit 10.4.2 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.2-1ubuntu2.14
Configuration: /tmp/simple-tenancy/phpunit.xml.dist

...........                                                       11 / 11 (100%)

Time: 00:00.073, Memory: 22.00 MB

OK (11 tests, 16 assertions)
```

~~Note: I did not test this with Laravel 10, I just appended it to the list of framework versions.~~
EDIT: It does work fine with Laravel 10 :+1: 